### PR TITLE
fix(docs): update broken Squads link to current create-squad URL

### DIFF
--- a/developers/developer-tooling/squads-multisig.md
+++ b/developers/developer-tooling/squads-multisig.md
@@ -10,7 +10,7 @@ Squads Protocol is a collection of programs (smart contracts) that enables devel
 
 #### Public UI <a href="#getting-started" id="getting-started"></a>
 
-The [public UI](https://backup.app.squads.so/create) is recommended. Navigate to settings and set the RPC URL to a valid [Eclipse endpoint](https://docs.squads.so/main/development/cli/installation), and the program ID to the one above.&#x20;
+The [public UI](https://app.squads.so/create-squad) is recommended. Navigate to settings and set the RPC URL to a valid [Eclipse endpoint](https://docs.squads.so/main/development/cli/installation), and the program ID to the one above.&#x20;
 
 #### CLI
 


### PR DESCRIPTION
The original link https://backup.app.squads.so/create returned a 404. Replaced it with the current working link https://app.squads.so/create-squad.